### PR TITLE
Extend the tool to read argument value from `stdin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ Assuming you have the following variables setup:
 
 `certificate-tool remove --thumbprint $thumbprint`
 
+### With PEM formatted files without a private key
+
+Assuming you have the following variables setup:
+
+- \$thumbprint: certificate's thumbprint
+
+`certificate-tool add --cert ./cert.crt`
+
+`certificate-tool remove --thumbprint $thumbprint`
+
+### Advanced
+
+You can use `-` to read the argument value from `stdin`. For instance,
+
+`cat ./cert.crt | certificate-tool add --cert -`
+
+`base64 -w0 ./cert.crt | certificate-tool add --base64 -`
+
+`ls ./*.crt | certificate-tool add --cert -`
+
 ## License
 
 Copyright © 2020, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license [here](https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE).

--- a/src/GSoft.CertificateTool.csproj
+++ b/src/GSoft.CertificateTool.csproj
@@ -19,6 +19,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CommandLineParser" Version="2.8.0" />
+      <PackageReference Include="CommandLineParser" Version="2.9.1" />
     </ItemGroup>
 </Project>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -36,7 +36,7 @@ namespace GSoft.CertificateTool
                         if (!string.IsNullOrEmpty(opts.PfxPath))
                         {
                             InstallPfxCertificate(
-                                opts.PfxPath,
+                                opts.PfxPath.Equals("-") ? Console.ReadLine() : opts.PfxPath,
                                 opts.Password,
                                 Enum.Parse<StoreName>(
                                     opts.StoreName,
@@ -48,7 +48,7 @@ namespace GSoft.CertificateTool
                         else if (!string.IsNullOrEmpty(opts.Base64))
                         {
                             InstallBase64Certificate(
-                                opts.Base64,
+                                opts.Base64.Equals("-") ? Console.ReadLine() : opts.Base64,
                                 opts.Password,
                                 Enum.Parse<StoreName>(
                                     opts.StoreName,
@@ -60,7 +60,7 @@ namespace GSoft.CertificateTool
                         else if (!string.IsNullOrEmpty(opts.PublicCertPath))
                         {
                             InstallPemCertificate(
-                                opts.PublicCertPath,
+                                opts.PublicCertPath.Equals("-") ? Console.ReadLine() : opts.PublicCertPath,
                                 opts.PrivateKeyPath,
                                 opts.Password,
                                 Enum.Parse<StoreName>(


### PR DESCRIPTION
To make it more flexible.

NOTE: Upgrading CommandLineParser to 2.9.1 was required to be able to treat a single dash as a value rather than an option, see: https://github.com/commandlineparser/commandline/issues/735.